### PR TITLE
Fixes Acceptance test concurrency bug

### DIFF
--- a/src/Core/Constants/TestIds.cs
+++ b/src/Core/Constants/TestIds.cs
@@ -1,20 +1,25 @@
 namespace Rundog.Core.Constants;
 
 /// <summary>
-///     A collection of constant test handles used throughout the application for testing purposes.
+/// A collection of constant test handles used throughout the application for testing purposes.
 /// </summary>
 public static class TestIds
 {
     /// <summary>
-    ///     Site global elements
+    /// Site global elements
     /// </summary>
     public static class Site
     {
         /// <summary>
-        ///     The main title of the Site.
-        ///     Displayed in the tab within the browser
+        /// The main title of the Site.
+        /// Displayed in the tab within the browser
         /// </summary>
         public const string Title = "site-title";
+
+        /// <summary>
+        /// The identifier for the loading indicator element used in testing.
+        /// </summary>
+        public const string LoadingIndicator = "loading-indicator";
     }
 
     /// <summary>
@@ -61,7 +66,7 @@ public static class TestIds
     }
 
     /// <summary>
-    ///     Test handles for elements within the developer Hero
+    /// Test handles for elements within the developer Hero
     /// </summary>
     public static class Hero
     {
@@ -87,7 +92,7 @@ public static class TestIds
     }
 
     /// <summary>
-    ///     Test handles for elements within the command decoration section.
+    /// Test handles for elements within the command decoration section.
     /// </summary>
     public static class CommandDecoration
     {

--- a/src/Web/wwwroot/index.html
+++ b/src/Web/wwwroot/index.html
@@ -18,7 +18,7 @@
              dark:bg-gray-900 dark:text-gray-50
              border border-gray-900 dark:border-gray-50">
     <div id="app">
-        <svg class="loading-progress">
+        <svg class="loading-progress" data-testid="loading-indicator">
             <circle cx="50%" cy="50%" r="40%"/>
             <circle cx="50%" cy="50%" r="40%"/>
         </svg>

--- a/tests/Web.Acceptance.Tests/Extensions/PageExtensions.cs
+++ b/tests/Web.Acceptance.Tests/Extensions/PageExtensions.cs
@@ -14,14 +14,8 @@ public static class PageExtensions
     {
         IResponse? response = await page.GotoAsync(url, options);
 
-        bool isLoading = await page.GetByTestId(TestIds.Site.LoadingIndicator)
-            .IsVisibleAsync();
-
-        if (isLoading)
-        {
-            await page.GetByTestId(TestIds.Site.LoadingIndicator)
-                .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Hidden });
-        }
+        await page.GetByTestId(TestIds.Site.LoadingIndicator)
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Hidden });
 
         await page.GetByTestId(TestIds.Main.Section)
             .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });

--- a/tests/Web.Acceptance.Tests/Extensions/PageExtensions.cs
+++ b/tests/Web.Acceptance.Tests/Extensions/PageExtensions.cs
@@ -1,5 +1,3 @@
-using Microsoft.Playwright;
-
 namespace Rundog.Acceptance.Tests.Extensions;
 
 public static class PageExtensions
@@ -12,11 +10,22 @@ public static class PageExtensions
     /// <param name="url">The URL to navigate to</param>
     /// <param name="options">Optional navigation options</param>
     /// <returns>The response from the navigation</returns>
-    public async static Task<IResponse?> LoadAsync(this IPage page, string url, PageGotoOptions? options = null)
+    public static async Task<IResponse?> LoadAsync(this IPage page, string url, PageGotoOptions? options = null)
     {
         IResponse? response = await page.GotoAsync(url, options);
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await page.WaitForSelectorAsync($"[data-testid='{TestIds.Main.Section}']");
+
+        bool isLoading = await page.GetByTestId(TestIds.Site.LoadingIndicator)
+            .IsVisibleAsync();
+
+        if (isLoading)
+        {
+            await page.GetByTestId(TestIds.Site.LoadingIndicator)
+                .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Hidden });
+        }
+
+        await page.GetByTestId(TestIds.Main.Section)
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+
         return response;
     }
 }

--- a/tests/Web.Acceptance.Tests/Web.Acceptance.Tests.csproj
+++ b/tests/Web.Acceptance.Tests/Web.Acceptance.Tests.csproj
@@ -30,4 +30,10 @@
     <ProjectReference Include="..\..\src\Core\Core.csproj"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardised test IDs across the app and added a dedicated loading-indicator identifier to support automation.

- Tests
  - Acceptance tests now wait for the loading indicator to finish before verifying page content, improving reliability and reducing flakiness.
  - Test runner configuration is copied to build output for consistent test execution.

No user-facing visual or behavioural changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->